### PR TITLE
fix: GitHub Actions workflow to use pnpm

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -23,20 +23,25 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
-          cache: 'npm'
+      
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: npm test
+        run: pnpm test
         continue-on-error: true # Remove this when tests are set up
 
       - name: Run linter
-        run: npm run lint
+        run: pnpm run lint
 
       - name: Build application
-        run: npm run build
+        run: pnpm run build
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -20,17 +20,22 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
-          cache: 'npm'
+      
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Run linter
-        run: npm run lint
+        run: pnpm run lint
         continue-on-error: true # Remove when linting is fixed
 
       - name: Run tests
-        run: npm test
+        run: pnpm test
         continue-on-error: true # Remove when tests are added
 
       - name: Setup Supabase CLI


### PR DESCRIPTION
## Fix for failing CI/CD

### Problem
- GitHub Actions were failing because workflows used `npm ci` but project uses `pnpm`
- This prevented migrations from running

### Solution  
- Updated all workflows to use pnpm
- Added pnpm setup step
- Changed all npm commands to pnpm equivalents

### This will fix
- Deploy to Production workflow
- Test and Deploy workflow
- Migrations will now run successfully