### PR TITLE
fix: add Supabase environment variables for build

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -42,6 +42,9 @@ jobs:
         continue-on-error: true # Temporarily disabled until ESLint is configured
 
       - name: Build application
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: https://jbqljjyctbsyawijlxfa.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         run: pnpm run build
 
       - name: Setup Supabase CLI


### PR DESCRIPTION
## Fix for Build Failure

Adds the required environment variables for Next.js build to succeed:
- NEXT_PUBLIC_SUPABASE_URL (hardcoded as it's public)
- NEXT_PUBLIC_SUPABASE_ANON_KEY (from GitHub secrets)

This will allow the build to complete and migrations to run.