### PR TITLE
fix: pass database password to supabase link

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -53,7 +53,8 @@ jobs:
           version: latest
 
       - name: Link Supabase project
-        run: supabase link --project-ref ${{ secrets.PRODUCTION_PROJECT_ID }}
+        run: |
+          supabase link --project-ref ${{ secrets.PRODUCTION_PROJECT_ID }} --password "${{ secrets.PRODUCTION_DB_PASSWORD }}"
 
       - name: Run migrations
         run: |


### PR DESCRIPTION
Fixes the Supabase link authentication error by explicitly passing the database password to the link command.