### PR TITLE
fix: use access token for Supabase authentication

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -53,10 +53,14 @@ jobs:
           version: latest
 
       - name: Link Supabase project
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
-          supabase link --project-ref ${{ secrets.PRODUCTION_PROJECT_ID }} --password "${{ secrets.PRODUCTION_DB_PASSWORD }}"
+          supabase link --project-ref ${{ secrets.PRODUCTION_PROJECT_ID }}
 
       - name: Run migrations
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
           echo "🚀 Deploying migrations to production..."
           supabase db push --no-verify


### PR DESCRIPTION
Uses SUPABASE_ACCESS_TOKEN environment variable for authenticating with Supabase CLI instead of database password