### PR TITLE
fix: use direct DB host for migrations (expert solution)

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -54,11 +54,12 @@ jobs:
 
       - name: Run migrations
         env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_ID: ${{ secrets.PRODUCTION_PROJECT_ID }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_DB_PASSWORD }}
         run: |
-          echo "🚀 Deploying migrations to production..."
-          # Using db-url directly to avoid SASL auth issues with special characters in password
-          supabase db push --db-url "postgresql://postgres.${{ secrets.PRODUCTION_PROJECT_ID }}:${{ secrets.PRODUCTION_DB_PASSWORD_ENCODED }}@aws-0-us-east-1.pooler.supabase.com:5432/postgres"
+          echo "🚀 Deploying migrations to production (using direct DB host)..."
+          # Use direct database host (not pooler) with key=value connection string to avoid URL encoding issues
+          supabase db push --db-url "host=db.${SUPABASE_PROJECT_ID}.supabase.co port=5432 dbname=postgres user=postgres password=${SUPABASE_DB_PASSWORD} sslmode=require"
 
       - name: Create release tag
         if: success()


### PR DESCRIPTION
## The Solution (from GPT5 & Gemini analysis)

The SASL auth error was happening because we were using the **pooler host for migrations**, which is incorrect.

### Key Changes:
- ✅ Use **direct database host** (`db.<ref>.supabase.co`) for migrations
- ✅ Use **key=value connection string** (no URL encoding needed!)
- ✅ Use simple `postgres` username (not `postgres.<projectRef>`)
- ✅ Use raw password from secrets (no encoding)

### Why this works:
- **Pooler host** (`aws-0-us-east-1.pooler.supabase.com`) = for app queries
- **Direct DB host** (`db.<ref>.supabase.co`) = for DDL/migrations

This is the architecturally correct approach and should finally resolve all SASL auth errors.